### PR TITLE
Grid feature

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -23,7 +23,7 @@ function makeGrid(num){
 
 // Etch-a-Sketch behavior
 function addToggleClass(){
-    this.className = `toggle`;
+    this.classList.add("toggle");
 }
 
 makeGrid(50) // Test Grid

--- a/styles.css
+++ b/styles.css
@@ -23,12 +23,10 @@
     display: inline-block;
 }
 
-#grid>div>div {
-    height: 10px;
-    width: 10px;
-}
 .cell {
     background-color: lightgrey;
+    height: 10px;
+    width: 10px;
 }
 .toggle {
     background-color: black;

--- a/styles.css
+++ b/styles.css
@@ -19,14 +19,21 @@
     margin-bottom: 20px;
 }
 
+#grid {
+    height: 340px;
+    width: 500px;
+    display: flex;
+}
+
 #grid>div {
-    display: inline-block;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
 }
 
 .cell {
+    flex: 1;
     background-color: lightgrey;
-    height: 10px;
-    width: 10px;
 }
 .toggle {
     background-color: black;

--- a/test.md
+++ b/test.md
@@ -1,0 +1,1 @@
+a test file

--- a/test.md
+++ b/test.md
@@ -1,1 +1,0 @@
-a test file


### PR DESCRIPTION
Added static #grid dimensions and various Flexbox settings to _styles_ in order for cells to fill all available space within the dimensions. Additionally, fixed a bug in _scripts_ where the .toggle class incorrectly replaced all the class definitions of a div, resulting in incorrect coloring behavior. The new method (.classList.add()) fixes this by keeping all original classes and adding the new .toggle class.

Depending on the number entered into makeGrid(), the cells will now resize to the correct size.